### PR TITLE
Fix .tilrc config merge

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -9,7 +9,7 @@ let config = {
 try {
   const tilrcRaw = fs.readFileSync(rc);
   const tilrc = JSON.parse(tilrcRaw);
-  config = { ...config, tilrc };
+  config = { ...config, ...tilrc };
 } catch (err) {
   // nothing
 }


### PR DESCRIPTION
.tilrc contents was put under `tilrc` key inside `config` instead
of mergin those two
